### PR TITLE
Eliminate typings folder in favor of per-target types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,20 +39,18 @@
   "exports": {
     ".": {
       "require": "./build/cjs/index.js",
-      "import": "./build/esm/index.js",
-      "types": "./build/typings/index.d.ts"
+      "import": "./build/esm/index.js"
     }
   },
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",
-  "types": "./build/typings/index.d.ts",
   "files": [
     "./build"
   ],
   "scripts": {
     "prebuild": "npm run clean && npm run check:version",
-    "build": "npx tsc --build ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.typings.json",
-    "postbuild": "npx shx rm ./build/typings/browser-shim.d.ts && npx shx cp ./src/browser-shim.ts ./build/typings && npx ts-node ./scripts/package.json.ts",
+    "build": "npx tsc --build ./tsconfig.cjs.json ./tsconfig.cjs.d.json ./tsconfig.esm.json ./tsconfig.esm.d.json",
+    "postbuild": "npx shx rm ./build/*/browser-shim.d.ts && npx shx cp ./src/browser-shim.ts ./build/cjs && npx shx cp ./src/browser-shim.ts ./build/esm && npx ts-node ./scripts/package.json.ts",
     "prebuild:benchmarks": "npm run clean",
     "build:benchmarks": "npx tsc --project ./benchmarks/tsconfig.json",
     "build:examples": "npm run --prefix ./examples build",
@@ -65,9 +63,7 @@
     "check:type": "npx npm-run-all --npm-path npm \"check:type:*\"",
     "check:type:cjs": "npx tsc --project ./tsconfig.cjs.json --noEmit",
     "check:type:esm": "npx tsc --project ./tsconfig.esm.json --noEmit",
-    "check:type:typings": "npx tsc --project ./tsconfig.typings.json --noEmit --emitDeclarationOnly false",
     "check:type:benchmarks": "npx tsc --project ./benchmarks/tsconfig.json --noEmit",
-    "precheck:type:examples": "npx tsc --project ./tsconfig.typings.json",
     "check:type:examples": "npx tsc --project ./examples/tsconfig.json --noEmit",
     "check:type:scripts": "npx tsc --project ./scripts/tsconfig.json --noEmit",
     "check:version": "npx ts-node ./scripts/version.ts",

--- a/src/utils/buildTypeDefsAndResolvers.ts
+++ b/src/utils/buildTypeDefsAndResolvers.ts
@@ -1,10 +1,14 @@
 import type { GraphQLSchema } from "graphql";
 import { printSchema } from "graphql";
+import type { ResolversMap } from "@/typings";
 import type { BuildSchemaOptions } from "./buildSchema";
 import { buildSchema, buildSchemaSync } from "./buildSchema";
 import { createResolversMap } from "./createResolversMap";
 
-function createTypeDefsAndResolversMap(schema: GraphQLSchema) {
+function createTypeDefsAndResolversMap(schema: GraphQLSchema): {
+  typeDefs: string;
+  resolvers: ResolversMap;
+} {
   const typeDefs = printSchema(schema);
   const resolvers = createResolversMap(schema);
   return { typeDefs, resolvers };

--- a/tsconfig.cjs.d.json
+++ b/tsconfig.cjs.d.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.cjs.json",
+  "compilerOptions": {
+    // See https://github.com/webstrand/typescript-remove-comments-not-from-declarations for the source of inspiration.
+
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "removeComments": false,
+
+    // performance enhancement
+    "disableSolutionSearching": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true
+  }
+}

--- a/tsconfig.esm.d.json
+++ b/tsconfig.esm.d.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.esm.json",
+  "compilerOptions": {
+    // See https://github.com/webstrand/typescript-remove-comments-not-from-declarations for the source of inspiration.
+
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "removeComments": false,
+
+    // performance enhancement
+    "disableSolutionSearching": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true
+  }
+}

--- a/tsconfig.typings.json
+++ b/tsconfig.typings.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./build/typings",
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "removeComments": false
-  }
-}


### PR DESCRIPTION
Took some doing since there's no nice way in TS of omitting comments from the resulting JS files but keeping them in the TS files. See https://github.com/microsoft/TypeScript/issues/14619 for the relevant issue discussing this.